### PR TITLE
Corrige os Erros de Rota do Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+    from = "/*"
+    to = "/index.html"
+    status = 200


### PR DESCRIPTION
## Descrição 

Corrige erro de rota que é gerado pelo deploy do netlify. O problema ocorria após pressionar a tecla de atualizar a página (F5), por exemplo.

Para testes, clique por exemplo em "equipe" no site, e dê f5:
* Antes: https://deploy-preview-8--miaajuda.netlify.app/
* Depois: https://deploy-preview-10--miaajuda.netlify.app/

## Resolve (Issues)

Não há issues ou histórias de usuário relacionadas a esse _pull request_.

## Tarefas gerais realizadas

- [x] Corrige erros de rota gerados pela ação de um "F5" (por exemplo).